### PR TITLE
Fixed: OAuth2 introspection cannot identify 'scope' claim on token

### DIFF
--- a/lib/policies/oauth2-introspect/oauth2-introspect.js
+++ b/lib/policies/oauth2-introspect/oauth2-introspect.js
@@ -13,7 +13,8 @@ module.exports = function (actionParams) {
     const requestedScopes = req.egContext.apiEndpoint.scopes;
 
     const scopeCheck = (tokenData, done) => {
-      const avaiableScopes = tokenData.scopes ? tokenData.scopes.split(' ') : [];
+      const tokenDataScopes = tokenData.scope || tokenData.scopes;
+      const avaiableScopes = tokenDataScopes ? tokenDataScopes.split(' ') : [];
 
       if (requestedScopes.every(scope => avaiableScopes.includes(scope))) {
         return done(null, tokenData);


### PR DESCRIPTION
…mentation

Now OAuth2 introspection can read 'scope'  and 'scopes' claims from different OAuth2 Token scopes implementations